### PR TITLE
Return the server, not the app, in app.listen()

### DIFF
--- a/lib/idp.js
+++ b/lib/idp.js
@@ -150,8 +150,7 @@ function create (options) {
   const _listen = app.listen.bind(app)
   app.listen = (port, cb) => {
     app.options = setOptions(extend(true, {port}, app.options))
-    _listen(port, cb)
-    return app
+    return _listen(port, cb)
   }
 
   return app


### PR DESCRIPTION
Because `app.listen()` returns the app, not the server, we can't close it (say when we tear down tests). This makes `app.listen()` return the server, like express does.