### PR TITLE
Add id=userId to select

### DIFF
--- a/lib/views/login.ejs
+++ b/lib/views/login.ejs
@@ -16,7 +16,7 @@
       <fieldset name="credentials">
         <% if (enumerateUsers) { %>
           <label for="userId"><%= labels.selectuser %></label>
-          <select name="userid">
+          <select name="userid" id="userId">
             <% users.forEach(user => { %>
               <option value="<%= user.id %>"><%= user.name || user.username %></option>
             <% }) %>


### PR DESCRIPTION
The label for the userId `<select>` box has a `for="userId"` attribute, but the select doesn't have that as it's id attribute. This change fixes that.